### PR TITLE
Set the tftp directoy user/group via attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,3 +23,12 @@ default['tftp']['directory'] = '/var/lib/tftpboot'
 default['tftp']['address'] = '0.0.0.0:69'
 default['tftp']['tftp_options'] = '--secure'
 default['tftp']['options'] = '-s'
+
+case node['platform_family']
+when 'rhel', 'fedora'
+  default['tftp']['owner'] = 'nobody'
+  default['tftp']['group'] = 'nobody'
+when 'debian'
+  default['tftp']['owner'] = 'root'
+  default['tftp']['group'] = 'root'
+end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -23,8 +23,8 @@ when 'rhel', 'fedora'
   package 'tftp-server'
 
   directory node['tftp']['directory'] do
-    owner 'nobody'
-    group 'nobody'
+    owner node['tftp']['owner']
+    group node['tftp']['group']
     mode '0755'
     recursive true
     action :create
@@ -47,8 +47,8 @@ when 'debian'
   package 'tftpd-hpa'
 
   directory node['tftp']['directory'] do
-    owner 'root'
-    group 'root'
+    owner node['tftp']['owner']
+    group node['tftp']['group']
     mode '0755'
     recursive true
     action :create


### PR DESCRIPTION
For various reasons, we need to have the tftproot as a different user. In the event that we're not the only ones needing to do this, this change allows the setting of owner/group via attributes.