### PR TITLE
Set the tftp directory permissions via attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,7 @@
 
 default['tftp']['username'] = 'tftp'
 default['tftp']['directory'] = '/var/lib/tftpboot'
+default['tftp']['permissions'] = '0755'
 default['tftp']['address'] = '0.0.0.0:69'
 default['tftp']['tftp_options'] = '--secure'
 default['tftp']['options'] = '-s'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -26,7 +26,7 @@ when 'rhel', 'fedora'
   directory node['tftp']['directory'] do
     owner 'nobody'
     group 'nobody'
-    mode '0755'
+    mode node['tftp']['permissions']
     recursive true
     action :create
   end
@@ -50,7 +50,7 @@ when 'debian'
   directory node['tftp']['directory'] do
     owner 'root'
     group 'root'
-    mode '0755'
+    mode node['tftp']['permissions']
     recursive true
     action :create
   end


### PR DESCRIPTION
### Description

This change is a knock on change to https://github.com/chef-cookbooks/tftp/pull/5/files in that it allows the tftp directory permissions to be modified by an attribute too. Defaults remain the same, however.

### Check List
- [X] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing. (not applicable)
- [ ] New functionality has been documented in the README if applicable (not applicable)
- [X] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


