### PR TITLE
Set the tftp directory owner/group via attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,3 +24,12 @@ default['tftp']['permissions'] = '0755'
 default['tftp']['address'] = '0.0.0.0:69'
 default['tftp']['tftp_options'] = '--secure'
 default['tftp']['options'] = '-s'
+
+case node['platform_family']
+when 'rhel', 'fedora'
+  default['tftp']['owner'] = 'root'
+  default['tftp']['group'] = 'root'
+when 'debian'
+  default['tftp']['owner'] = 'root'
+  default['tftp']['group'] = 'nogroup'
+end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -24,8 +24,8 @@ when 'rhel', 'fedora'
   package 'xinetd'
 
   directory node['tftp']['directory'] do
-    owner 'nobody'
-    group 'nobody'
+    owner node['tftp']['owner']
+    group node['tftp']['group']
     mode node['tftp']['permissions']
     recursive true
     action :create
@@ -48,8 +48,8 @@ when 'debian'
   package 'tftpd-hpa'
 
   directory node['tftp']['directory'] do
-    owner 'root'
-    group 'root'
+    owner node['tftp']['owner']
+    group node['tftp']['group']
     mode node['tftp']['permissions']
     recursive true
     action :create


### PR DESCRIPTION
### Description

This change allows the tftp directory owner/group values to be modified by an attribute. Defaults are modified to be in line with OS defaults (per discussion https://github.com/chef-cookbooks/tftp/pull/5).

### Check List
- [X] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing. (not applicable)
- [ ] New functionality has been documented in the README if applicable (not applicable)
- [X] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD