### PR TITLE
Clean up service commands

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -60,9 +60,7 @@ when 'debian'
   end
 
   service 'tftpd-hpa' do
-    restart_command 'service tftpd-hpa restart'
-    start_command 'service tftpd-hpa start'
-    supports restart: true, status: true, reload: true
+    supports restart: true, status: true
     action [:enable, :start]
   end
 end


### PR DESCRIPTION
### Description

Start and restart commands are unnecessary -- these will be handled by the provider.
tftpd-hpa service doesn't support reload

### Issues Resolved

Not applicable

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

