### PR TITLE
Add kitchen-dokken gem to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ matrix:
   include:
     - before_script:
       - eval "$(/opt/chefdk/bin/chef shell-init bash)"
+      - /opt/chefdk/embedded/bin/chef gem install kitchen-dokken
       - /opt/chefdk/embedded/bin/chef --version
       - /opt/chefdk/embedded/bin/cookstyle --version
       - /opt/chefdk/embedded/bin/foodcritic --version


### PR DESCRIPTION
The Travis build for 16.04 is failing at the moment due to not being able to restart the tftpd-hpa service. Looking at https://github.com/chef-cookbooks/cron/issues/79 and https://github.com/chef-cookbooks/cron/pull/81, it looks like the thing that might be missing is the dokken gem.

Sorry if I'm off base -- this is mostly an educated guess. Hoping that the CI build for this PR tells me if I'm on the right track.