### PR TITLE
chore: migrate to Policyfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install Cinc Workstation
         uses: sous-chefs/.github/.github/actions/install-workstation@8.0.2
 
+      - name: Install cookbooks
+        run: chef install Policyfile.rb
+
       - name: Run Kitchen
         env:
           CHEF_LICENSE: accept-no-persist

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Cinc Workstation
         uses: sous-chefs/.github/.github/actions/install-workstation@8.0.2
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Limitations
+# AGENTS.md
 
 ## Package Availability
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+name 'tftp'
+
+run_list 'recipe[test::default]'
+
+cookbook 'tftp', path: '.'
+cookbook 'test', path: 'test/cookbooks/test'

--- a/chefignore
+++ b/chefignore
@@ -83,13 +83,6 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
-cookbooks/*
-tmp
-
 # Bundler #
 ###########
 vendor/*

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -9,6 +9,7 @@ transport:
 
 provisioner:
   name: dokken
+  policyfile: Policyfile.rb
 
 platforms:
   - name: almalinux-9

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -1,6 +1,7 @@
 ---
 provisioner:
   name: chef_infra
+  policyfile: Policyfile.rb
   product_name: chef
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   channel: stable

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -9,6 +9,7 @@ transport:
 
 provisioner:
   name: chef_infra
+  policyfile: Policyfile.rb
   product_name: chef
   product_version: latest
   channel: stable
@@ -31,10 +32,6 @@ platforms:
   - name: rockylinux-9
   - name: ubuntu-24.04
 
-x-run_lists:
-  default: &default_run_list
-    - recipe[test::default]
-
 x-attributes:
   default: &default_attributes
     tftp_test:
@@ -51,6 +48,5 @@ x-verifiers:
 
 suites:
   - name: default
-    run_list: *default_run_list
     attributes: *default_attributes
     verifier: *default_verifier

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT


### PR DESCRIPTION
## Summary
- add Policyfile.rb for local tftp/test cookbook dependency resolution
- remove Berksfile and stale Berkshelf references
- switch ChefSpec, Kitchen, CI, and Copilot setup to Policyfile install/use
- replace LIMITATIONS.md with AGENTS.md per migration guidance

## Validation
- chef install Policyfile.rb
- cookstyle
- env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec --format documentation
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list
- env -u KITCHEN_LOCAL_YAML kitchen list
- markdownlint-cli2 "**/*.md" "#CHANGELOG.md"
- yamllint .
- actionlint
- git diff --check
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen test default-ubuntu-2404 --destroy=always